### PR TITLE
商品購入確定画面の実装

### DIFF
--- a/app/views/products/comfirm.html.haml
+++ b/app/views/products/comfirm.html.haml
@@ -1,3 +1,39 @@
-= form_with url: buying_product_path do
-  :plain
-    <script type="text/javascript" src="https://checkout.pay.jp" class="payjp-button" data-key="pk_test_8119584aef930bf4412e634e"></script>
+.buying-container
+  .buying-container__header
+    = link_to image_tag('logo.svg', size: '185x49', class: 'buying-container__header__image'), root_path
+
+  .buying-container__main{ style: "padding-bottom: 100px;" }
+    .buying-container__main__head
+      注文を確定しますか？
+    .buying-container__main__content
+      .buying-container__main__content__product
+        =image_tag 'product.jpg', class: 'buying-container__main__content__product__image', size: '64x64'
+        .buying-container__main__content__product__name
+          商品名をここに入力商品名をここに入力商品名をここに入力
+      .buying-container__main__content__price
+        ¥9,999
+        %span.buying-container__main__content__price__detail
+          送料込み
+      .buying-container__main__content__point
+        ポイントはありません
+      .buying-container__main__content__payment
+        支払い金額
+        .buying-container__main__content__payment__right
+          ¥9,999
+      .buying-container__main__content__alert{style: "margin-top: 25px;"}
+        = form_with url: buying_product_path do
+          :plain
+          <script type="text/javascript" src="https://checkout.pay.jp" class="payjp-button" data-key="pk_test_8119584aef930bf4412e634e"></script>
+  .buying-container__footer
+    %ul.buying-container__footer__list
+      %li.buying-container__footer__list__part
+        プライバシーポリシー
+      %li.buying-container__footer__list__part
+        メルカリ利用規約
+      %li.buying-container__footer__list__part
+        特定商取引に関する表記
+    =link_to '', class: 'buying-container__footer__link' do
+      =image_tag 'logo-gray.svg', size: '80x65', class: 'buying-container__footer__link__logo'
+    .buying-container__footer__copyright
+      © 2019 Mercari
+


### PR DESCRIPTION
# What
商品購入確定時に「カードで支払う」を選択し、カード情報を入力することで実際にカードで支払うためのビューの作成

# Why
メルカリのクローン作成のために必須の実装であるから