### PR TITLE
微調整・修正（４）

### DIFF
--- a/app/assets/stylesheets/_identification.scss
+++ b/app/assets/stylesheets/_identification.scss
@@ -40,6 +40,16 @@
         p {
           font-size: 12px;
         }
+        .name-form {
+          font-size: 12px;
+          font-weight: 500;
+        }
+        .family_name {
+          display: inline-block;
+        }
+        .first_name {
+          display: inline;
+        }
         .input-defalt {
           width: 90%;
           margin: 8px 0 0;

--- a/app/views/mypages/edit.html.haml
+++ b/app/views/mypages/edit.html.haml
@@ -10,7 +10,7 @@
       = image_tag('mypage-background.jpg', class: "mypage-background")
       = image_tag('user-icon.png', class: "user-icon")
       = form_tag do
-        %input{type:"text",name:"nickname",value:"",placeholder:"例)AYA☆セール中",class: "input-defalt", style:"margin-top: 70px;"}
+        %input{type:"text",name:"nickname",value:current_user.nickname,placeholder:"例)AYA☆セール中",class: "input-defalt", style:"margin-top: 70px;"}
     .profile-edit__context
       = form_tag do
         %textarea{type:"text",name:"introduction",value:"",placeholder:"例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪",class: "textarea-defalt"}

--- a/app/views/mypages/identification.html.haml
+++ b/app/views/mypages/identification.html.haml
@@ -17,19 +17,21 @@
           =fa_icon "chevron-right", class: "icon"
       .profile-identification__context__form-group
         %label.content お名前
-        %p テスト 太郎
+        %p.family_name= current_user.family_name 
+        %p.family_name= current_user.first_name
       .profile-identification__context__form-group
         %label.content お名前カナ
-        %p テスト タロウ
+        %p.family_name_kana= current_user.family_name_kana
+        %p.first_name_kana= current_user.first_name_kana
       .profile-identification__context__form-group
         %label.content 生年月日
-        %p 1991/11/11
+        %p= current_user.birthday
       .profile-identification__context__form-group
         = form_tag do
           %label.content 郵便番号
           %span.form-arbitrary 任意
           %br
-          %input{type:"text", name:"address-number",value:"" ,placeholder:"例）1234567", class: "input-defalt"}
+          %input{type:"text", name:"address-number",value:current_user.postal_code ,placeholder:"例）1234567", class: "input-defalt"}
       .profile-identification__context__form-group
         %label.content 都道府県
         %span.form-arbitrary  任意
@@ -42,19 +44,19 @@
           %label.content 市区町村
           %span.form-arbitrary  任意
           %br
-          %input{type:"text", name:"address-number",value:"" ,placeholder:"例）横浜市緑区", class: "input-defalt"}
+          %input{type:"text", name:"address-number",value:current_user.city ,placeholder:"例）横浜市緑区", class: "input-defalt"}
       .profile-identification__context__form-group
         = form_tag do
           %label.content 番地
           %span.form-arbitrary  任意
           %br
-          %input{type:"text", name:"address-number",value:"" ,placeholder:"例）青山1-1-1", class: "input-defalt"}
+          %input{type:"text", name:"address-number",value:current_user.house_number ,placeholder:"例）青山1-1-1", class: "input-defalt"}
       .profile-identification__context__form-group
         = form_tag do
           %label.content 建物名
           %span.form-arbitrary  任意
           %br
-          %input{type:"text", name:"address-number",value:"" ,placeholder:"例）柳ビル103", class: "input-defalt"}
+          %input{type:"text", name:"address-number",value:current_user.building_name ,placeholder:"例）柳ビル103", class: "input-defalt"}
 
     .profile-identification__update
       %button.btn-default.btn-red{type:"submit"} 登録する

--- a/app/views/mypages/identification.html.haml
+++ b/app/views/mypages/identification.html.haml
@@ -17,12 +17,14 @@
           =fa_icon "chevron-right", class: "icon"
       .profile-identification__context__form-group
         %label.content お名前
-        %p.family_name= current_user.family_name 
-        %p.family_name= current_user.first_name
+        %h4.name-form
+          %p.family_name= current_user.family_name 
+          %p.family_name= current_user.first_name
       .profile-identification__context__form-group
         %label.content お名前カナ
-        %p.family_name_kana= current_user.family_name_kana
-        %p.first_name_kana= current_user.first_name_kana
+        %h4.name-form
+          %p.family_name= current_user.family_name_kana
+          %p.first_name= current_user.first_name_kana
       .profile-identification__context__form-group
         %label.content 生年月日
         %p= current_user.birthday

--- a/app/views/products/exhibit.html.haml
+++ b/app/views/products/exhibit.html.haml
@@ -1,4 +1,4 @@
-- if user_signed_in?
+- if user_signed_in? && @product.seller_id == current_user.id
   %head
   = render 'shared/mypage-header'
   - breadcrumb :exhibit


### PR DESCRIPTION
# What
1.valueにcurrent_user.nameなどの値を入れた。
2.
- if user_signed_in?ではなく
- if user_signed_in? && @product.seller_id == current_user.id
のようにして、サインインしているかつ、seller_idとcurrent_user.idが同じ製品にのみ編集・削除のビューを表示させる実装。

# Why
1.新規登録時にDBに保存したものをもう一度入力しなければならないのは不便であるから。
2.今のままですとサインインしていれば、seller.idとcurrent_user.idが異なっていても編集・削除のビューが表示されるようになっているため。